### PR TITLE
Don't deploy on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ script:
  - dotnet build
  - dotnet pack
 after_success:
- - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" &&
- dotnet nuget push **/*.nupkg -k $NUGET_API_KEY -s https://www.nuget.org/api/v2/package
+ - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && dotnet nuget push **/*.nupkg -k $NUGET_API_KEY -s https://www.nuget.org/api/v2/package

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ script:
  - dotnet build
  - dotnet pack
 after_success:
- - test $TRAVIS_BRANCH = "master" && dotnet nuget push **/*.nupkg -k $NUGET_API_KEY -s https://www.nuget.org/api/v2/package
+ - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" &&
+ dotnet nuget push **/*.nupkg -k $NUGET_API_KEY -s https://www.nuget.org/api/v2/package


### PR DESCRIPTION
Merges to master should deploy to nuget.org, but only legit merge builds.

Travis was previously deploying on successful builds in pull-requests to master - before they were complete!

This will stop that.